### PR TITLE
Added quotes around $typeit inside conditional

### DIFF
--- a/.bin/lastpass-dmenu
+++ b/.bin/lastpass-dmenu
@@ -60,7 +60,7 @@ selid=$(printf '%s\n' "${entries[@]}" |
   dmenu -i -p 'LastPass: ' -l 7 |
   sed 's/^.*\[id: \([0-9]\{1,\}\)\].*$/\1/')
 
-if [ $typeit == "--typeit" ]; then
+if [ "$typeit" == "--typeit" ]; then
   lpass show --password ${selid} |
     tr -d '\n' |
     awk '{print "type \""$0"\""}' |


### PR DESCRIPTION
This stops the following error occuring when $1 / $typeit is empty.
[: ==: unary operator expected